### PR TITLE
Fix piping to commands by letting process exit naturally

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,6 @@ function CloudflareCli(options) {
       } else {
         console.log(result);
       }
-      process.exit();
     }).catch(function (error) {
       let formatter = new formatters.MessageFormatter();
       if (error.response) {


### PR DESCRIPTION
[Node.js' `process.stdout` is asynchronous when connected to a
pipe](https://github.com/nodejs/node/blob/master/doc/api/process.md#a-note-on-process-io),
so forcing an earlier `process.exit()` results in incomplete data being
output to the pipe.

This fixes usecases like `cfcli ls -f json | json`.