### PR TITLE
Fix "Invalid request headers" error with axios 1.12.0

### DIFF
--- a/bin/cfcli
+++ b/bin/cfcli
@@ -13,5 +13,10 @@ try {
   process.exit(1);
 }
 let params = { ...config, ...argv };
+// Remove email from params to force Bearer token authentication
+// The old API Key authentication (email + key) is deprecated and causes issues with newer axios
+if (params.token && params.email) {
+  delete params.email;
+}
 let cli = new CloudflareCli(params);
 cli.runCommand(argv._[0], params);

--- a/lib/apiClient.js
+++ b/lib/apiClient.js
@@ -14,6 +14,10 @@ export class ApiClient {
       timeout: 20000
     });
 
+    // Remove the Content-Type header set to undefined by axios
+    // which causes issues with Cloudflare API in newer axios versions
+    delete client.defaults.headers.common['Content-Type'];
+
     // if email is left blank, assume API token instead of API key.
     if (email === undefined) {
       client.defaults.headers.common['Authorization'] = "Bearer " + key;


### PR DESCRIPTION
This fixes compatibility issues with the newer axios version (1.12.0) that was causing "Invalid request headers" errors when making API requests to Cloudflare.

Changes:
- Remove Content-Type header set to undefined by axios which causes validation errors with Cloudflare API
- Force Bearer token authentication when both token and email are present in config, as the deprecated API Key method (X-Auth-Email/X-Auth-Key) doesn't work properly with newer axios versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)